### PR TITLE
Deploy generated static site to github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,34 @@
+name: github pages
+# see https://github.com/peaceiris/actions-hugo#getting-started
+
+on:
+  push:
+    branches:
+      - master
+      - feature/static-site-gh-pages  # Set a branch to deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.54.0'
+          extended: true
+
+      - name: Build
+        run: hugo
+        working-directory: src
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        # if: github.ref == 'refs/heads/master'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./src/public

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,7 @@ name: github pages
 on:
   push:
     branches:
-      # - master
-      - feature/static-site-gh-pages  # Set a branch to deploy
+      - '**' # matches every branch
 
 jobs:
   deploy:
@@ -19,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.54.0'
+          hugo-version: '0.54.0' # same like hugo in debian Dockerfile
           extended: true
 
       - name: Build
@@ -28,7 +27,8 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # if: github.ref == 'refs/heads/master'
+        # deploy generated content only for master branch
+        if: github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./src/public

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      # - master
       - feature/static-site-gh-pages  # Set a branch to deploy
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
           extended: true
 
       - name: Build
-        run: hugo
+        run: hugo --baseURL https://iteratec.github.io/traze-docs/
         working-directory: src
 
       - name: Deploy

--- a/src/config.toml
+++ b/src/config.toml
@@ -14,7 +14,7 @@ title = "traze"
 [[menu.top]]
     name = "Spectate"
     weight = 10
-    url = "https://traze.iteratec.de/watch/"
+    url = "watch/"
 
 # Site parameters
 [params]


### PR DESCRIPTION
Build docs with hugo using Github Actions.
Verified with a Github Action run to build and deploy using this branch.

See https://iteratec.github.io/traze-docs/